### PR TITLE
Layers catalog

### DIFF
--- a/marco/portal/data_catalog/static/data_catalog/js/data_catalog_themes.js
+++ b/marco/portal/data_catalog/static/data_catalog/js/data_catalog_themes.js
@@ -9,17 +9,17 @@ window.addEventListener('load', function () {
 
 loadedLayers = {};
 
-getCatalogEntry = function(layerId){
+getCatalogEntry = function(layerType, layerId){
   var layerKey = layerId.toString();
   if (Object.keys(loadedLayers).indexOf(layerKey) < 0) {
     $.ajax({
-      url: '/data_manager/get_layer_catalog_content/' + layerKey,
+      url: '/data_manager/get_layer_catalog_content/' + layerType + '/' + layerKey,
       success: function(data) {
-        $("#collapse-layer-" + layerKey).html(data.html);
+        $("#collapse-layer-" + layerType + "-" + layerKey).html(data.html);
         loadedLayers[layerKey] = 'Loaded';
       },
       error: function(data) {
-        $("#collapse-layer-" + layerKey).html('<div class="layer-loading-panel">Failed to retrieve layer info.</div>');
+        $("#collapse-layer-" + layerType + "-" + layerKey).html('<div class="layer-loading-panel">Failed to retrieve layer info.</div>');
         loadedLayers[layerKey] = 'Failed to load';
       }
     });

--- a/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_init_layer_info.html
+++ b/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_init_layer_info.html
@@ -3,11 +3,11 @@
     <span id="layer-info-{{ layer.slug_name }}"></span>
     <div class="row">
       <div class="col-sm-9">
-        <h4 id='layer-accordion-{{ layer.id }}'>
+        <h4 id='layer-accordion-{{layer.type}}-{{ layer.id }}'>
           <a class="layer-name collapsed" title="View in Marine Planner"
-              data-toggle="collapse" href="#collapse-layer-{{ layer.id }}"
-              aria-expanded="false" aria-controls="collapse-layer-{{ layer.id }}"
-              onclick="getCatalogEntry({{ layer.id }})">
+              data-toggle="collapse" href="#collapse-layer-{{layer.type}}-{{ layer.id }}"
+              aria-expanded="false" aria-controls="collapse-layer-{{layer.type}}-{{ layer.id }}"
+              onclick="getCatalogEntry('{{layer.type}}', {{ layer.id }})">
             {{layer.name}}</a>
           {% if layer.is_sublayer %}
             <span class="layer-parent-name">
@@ -17,18 +17,18 @@
         </h4>
       </div>
       <div class="col-sm-3">
-        {% if layer.bookmark_link %}{% if layer.is_sublayer or not layer.sublayers|length > 0 %}
+        {% if layer.bookmark_link %}{% if not layer.children|length > 0 and layer.type == 'layer' %}
           <a href="{{layer.bookmark_link}}" target="_blank" class="view-in-map">View in MAP</a>
         {% endif %}{% endif %}
-        {% if not layer.is_sublayer and layer.sublayers|length > 0 %}
-        <span id="parent-accordion-{{ layer.id }}">
-          <a class="parent-collapse" data-toggle="collapse" href="#collapse-parent-{{ layer.id }}"
-          aria-expanded="false" aria-controls="collapse-parent-{{ layer.id }}">Sublayers</a>
-        </span>
+        {% if layer.children|length > 0  and  layer.type == 'theme' %}
+            <span id="parent-accordion-{{layer.type}}-{{ layer.id }}">
+              <a class="parent-collapse" data-toggle="collapse" href="#collapse-parent-{{layer.type}}-{{ layer.id }}"
+              aria-expanded="false" aria-controls="collapse-parent-{{layer.type}}-{{ layer.id }}">Sublayers</a>
+            </span>
         {% endif %}
       </div>
     </div>
-    <div id="collapse-layer-{{ layer.id }}" class="collapse">
+    <div id="collapse-layer-{{layer.type}}-{{ layer.id }}" class="collapse">
       <div class='layer-loading-panel'>
         <p><img src="{% static 'img/ajax-loader.gif' %}"> Loading...<p>
       </div>

--- a/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_init_layer_info.html
+++ b/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_init_layer_info.html
@@ -9,11 +9,6 @@
               aria-expanded="false" aria-controls="collapse-layer-{{layer.type}}-{{ layer.id }}"
               onclick="getCatalogEntry('{{layer.type}}', {{ layer.id }})">
             {{layer.name}}</a>
-          {% if layer.is_sublayer %}
-            <span class="layer-parent-name">
-              / {{ layer.parent.name }}
-            </span>
-          {% endif %}
         </h4>
       </div>
       <div class="col-sm-3">

--- a/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_init_layer_info.html
+++ b/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_init_layer_info.html
@@ -23,7 +23,7 @@
         {% if layer.children|length > 0  and  layer.type == 'theme' %}
             <span id="parent-accordion-{{layer.type}}-{{ layer.id }}">
               <a class="parent-collapse" data-toggle="collapse" href="#collapse-parent-{{layer.type}}-{{ layer.id }}"
-              aria-expanded="false" aria-controls="collapse-parent-{{layer.type}}-{{ layer.id }}">Sublayers</a>
+              aria-expanded="false" aria-controls="collapse-parent-{{layer.type}}-{{ layer.id }}">Children</a>
             </span>
         {% endif %}
       </div>

--- a/marco/portal/data_catalog/templates/data_catalog/includes/theme_child.html
+++ b/marco/portal/data_catalog/templates/data_catalog/includes/theme_child.html
@@ -1,0 +1,12 @@
+{% include "data_catalog/includes/cacheless_init_layer_info.html" with layer=child %}
+<div id="collapse-parent-{{child.type}}-{{ child.id }}" class="collapse in catalog-tier" style="margin-left: 5rem">
+    {% for grandchild in child.children %}
+        {% if grandchild.type == 'layer' %}
+            <div class="sublayer-entry">
+                {% include "data_catalog/includes/cacheless_init_layer_info.html" with layer=grandchild %}
+            </div>
+        {% else %}
+            {% include "data_catalog/includes/theme_child.html" with child=grandchild %}
+        {% endif %}
+    {% endfor %}
+</div>

--- a/marco/portal/data_catalog/templates/data_catalog/theme.html
+++ b/marco/portal/data_catalog/templates/data_catalog/theme.html
@@ -22,14 +22,7 @@
   {% comment %} {% if children %} {% endcomment %}
     <div class="layer-list">
       {% for child in children %}
-        {% include "data_catalog/includes/cacheless_init_layer_info.html" with layer=child %}
-        <div id="collapse-parent-{{child.type}}-{{ child.id }}" class="collapse in">
-          {% for grandchild in child.children %}
-            <div class="sublayer-entry">
-              {% include "data_catalog/includes/cacheless_init_layer_info.html" with layer=grandchild %}
-            </div>
-          {% endfor %}
-        </div>
+        {% include "data_catalog/includes/theme_child.html" %}
       {% endfor %}
     </div>
   {% comment %} {% endif %} {% endcomment %}

--- a/marco/portal/data_catalog/templates/data_catalog/theme.html
+++ b/marco/portal/data_catalog/templates/data_catalog/theme.html
@@ -19,24 +19,20 @@
     {{ theme.description }}
     </div>
   </div>
-  {% if layers %}
+  {% comment %} {% if children %} {% endcomment %}
     <div class="layer-list">
-      {% for layer in layers %}
-        {% include "data_catalog/includes/cacheless_init_layer_info.html" %}
-        {% if layer.sublayers|length > 0 %}
-        <div id="collapse-parent-{{ layer.id }}" class="collapse in">
-        {% endif %}
-        {% for sublayer in layer.sublayers %}
-          <div class="sublayer-entry">
-            {% include "data_catalog/includes/cacheless_init_layer_info.html" with layer=sublayer %}
-          </div>
-        {% endfor %}
-        {% if layer.sublayers|length > 0 %}
+      {% for child in children %}
+        {% include "data_catalog/includes/cacheless_init_layer_info.html" with layer=child %}
+        <div id="collapse-parent-{{child.type}}-{{ child.id }}" class="collapse in">
+          {% for grandchild in child.children %}
+            <div class="sublayer-entry">
+              {% include "data_catalog/includes/cacheless_init_layer_info.html" with layer=grandchild %}
+            </div>
+          {% endfor %}
         </div>
-        {% endif %}
       {% endfor %}
     </div>
-  {% endif %}
+  {% comment %} {% endif %} {% endcomment %}
 {% endblock %}
 
 {% block media %}

--- a/marco/portal/data_catalog/views.py
+++ b/marco/portal/data_catalog/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import get_object_or_404, render
 from django.template import RequestContext
-from data_manager.models import *
+from data_manager import models as data_manager_models
+from layers.models import Theme, Layer
 from portal.base.models import PortalImage
 
 # hack for POR-224, until POR-206
@@ -11,25 +12,17 @@ def wagtail_feature_image(self):
 Theme.wagtail_feature_image = wagtail_feature_image
 
 def theme_query():
-    return Theme.objects.filter(visible=True).exclude(name='companion').extra(
-        select={
-            'layer_count': "SELECT COUNT(*) FROM data_manager_layer_themes as mm LEFT JOIN data_manager_layer as l ON mm.layer_id = l.id WHERE mm.theme_id = data_manager_theme.id AND l.layer_type != 'placeholder'"
-        }
-    ).order_by('order')
+    return Theme.objects.filter(is_visible=True).exclude(name='companion').order_by('order')
+
 
 def theme(request, theme_slug):
     from django.contrib.sites.shortcuts import get_current_site
     site = get_current_site(request)
     theme = get_object_or_404(theme_query(), name=theme_slug)
     template = 'data_catalog/theme.html'
-    # layers = [x.dictCache(site.pk) for x in theme.layer_set.all().exclude(layer_type='placeholder').exclude(is_sublayer=True).order_by('order')]
-    layers = []
-    for layer in theme.layer_set.all().exclude(layer_type='placeholder').exclude(is_sublayer=True).order_by('name'):
-        layers.append(layer.shortDict(site.pk))
-
     context = {
         'theme': theme,
-        'layers': layers,
+        'children': theme.shortDict()['children'],
     }
 
-    return render(request, template, context);
+    return render(request, template, context)


### PR DESCRIPTION
Coupled with the `layer-catalog` branch of the `mp-layers` repo (see PR2), this enables the data catalog to support the deeper nesting of themes and layers.