### PR TITLE
routing to support bad theme names, irregular catalog slashes, and mi…

### DIFF
--- a/marco/marco/urls.py
+++ b/marco/marco/urls.py
@@ -75,8 +75,9 @@ urlpatterns += [
     re_path(r'^documents/?', include(wagtaildocs_urls)),
 
     # url(r'^data-catalog/', include('portal.data_catalog.urls')),
-    re_path(r'^data-catalog/([A-Za-z0-9_-]+)/?$', data_catalog_views.theme, name="portal.data_catalog.views.theme"),
-    re_path(r'^data-catalog/[A-Za-z0-9_-]*/?', include('explore.urls')),
+    # TODO: we need to prevent Theme names with spaces or special characters.
+    re_path(r'^data-catalog/([A-Za-z0-9_\-|\s|\'(\'|\')\']+)/?$', data_catalog_views.theme, name="portal.data_catalog.views.theme"),
+    re_path(r'^data-catalog/[A-Za-z0-9_\-|\s|\'(\'|\')\']*/?', include('explore.urls')),
     re_path(r'^data_manager/?', include('layers.urls')),
     re_path(r'^old_manager/?', include('data_manager.urls')),
     # re_path(r'^data_manager/', include('data_manager.urls')),

--- a/marco/portal/data_catalog/static/data_catalog/js/data_catalog_themes.js
+++ b/marco/portal/data_catalog/static/data_catalog/js/data_catalog_themes.js
@@ -9,11 +9,15 @@ window.addEventListener('load', function () {
 
 loadedLayers = {};
 
-getCatalogEntry = function(layerType, layerId){
+getCatalogEntry = function(layerType, layerId, themeId) {
   var layerKey = layerId.toString();
   if (Object.keys(loadedLayers).indexOf(layerKey) < 0) {
+    let url = '/data_manager/get_layer_catalog_content/' + layerType + '/' + layerKey;
+    if (themeId !== undefined) {
+      url += '/' + themeId;
+    } 
     $.ajax({
-      url: '/data_manager/get_layer_catalog_content/' + layerType + '/' + layerKey,
+      url: url,
       success: function(data) {
         $("#collapse-layer-" + layerType + "-" + layerKey).html(data.html);
         loadedLayers[layerKey] = 'Loaded';

--- a/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_init_layer_info.html
+++ b/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_init_layer_info.html
@@ -7,7 +7,7 @@
           <a class="layer-name collapsed" title="View in Marine Planner"
               data-toggle="collapse" href="#collapse-layer-{{layer.type}}-{{ layer.id }}"
               aria-expanded="false" aria-controls="collapse-layer-{{layer.type}}-{{ layer.id }}"
-              onclick="getCatalogEntry('{{layer.type}}', {{ layer.id }})">
+              onclick="getCatalogEntry('{{layer.type}}', {{ layer.id }}, {{theme.id}})">
             {{layer.name}}</a>
         </h4>
       </div>

--- a/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_layer_info.html
+++ b/marco/portal/data_catalog/templates/data_catalog/includes/cacheless_layer_info.html
@@ -31,7 +31,11 @@
     </span>
     <span class="divider"></span>
     <span data-toggle="tooltip" data-placement="bottom" title="{{ layer.tiles }}">
-      <a class="btn btn-mini{% if not layer.tiles_link %} disabled{% endif %}" href="{{ layer.tiles_link }}">
+      {% if not theme is None %}
+        <a class="btn btn-mini{% if not layer.tiles_link %} disabled{% endif %}" href="/data-catalog/{{theme.name}}/{{ layer.tiles_link }}">
+      {% else %}
+        <a class="btn btn-mini{% if not layer.tiles_link %} disabled{% endif %}" href="/data-catalog/{{ layer.tiles_link }}">
+      {% endif %}
         tiles <i class="fa fa-external-link-square"></i>
       </a>
     </span>

--- a/marco/portal/data_catalog/views.py
+++ b/marco/portal/data_catalog/views.py
@@ -6,6 +6,7 @@ from django.template import RequestContext
 from data_manager import models as data_manager_models
 from layers.models import Theme, Layer, ChildOrder
 from portal.base.models import PortalImage
+from explore.views import tiles_page
 
 # hack for POR-224, until POR-206
 def wagtail_feature_image(self):
@@ -31,7 +32,10 @@ def theme_query(site):
 
 def theme(request, theme_slug):
     site = get_current_site(request)
-    theme = get_object_or_404(theme_query(site), name=theme_slug)
+    try:
+        theme = get_object_or_404(theme_query(site), name=theme_slug)
+    except:
+        return tiles_page(request, slug=theme_slug)
     template = 'data_catalog/theme.html'
     context = {
         'theme': theme,


### PR DESCRIPTION
…ssing theme for tiles links

V3.0.2 (in conjunction with mp-explore and mp-layers) will enforce consistent behavior regarding the 'tiles' link in the data catalog for layers. This also removed the 'OpenLayers' (v2) content from the 'tiles' pages.