### PR TITLE
include sum_data_results in search response

### DIFF
--- a/marco/portal/base/views.py
+++ b/marco/portal/base/views.py
@@ -63,11 +63,14 @@ def search(request, template=settings.WAGTAILSEARCH_RESULTS_TEMPLATE):
         # search layers from data_catalog
         layer_results.extend(Layer.objects.exclude(layer_type='placeholder').filter(themes__visible=True, name__icontains=query_string))
 
+    sum_data_results = len(theme_results) + len(layer_results) + len(data_needs_results) + len(resources_results)
+    
     return render(request, template, {
         'ocean_story_results': ocean_story_results,
         'calendar_news_results': calendar_news_results,
         'data_needs_results': data_needs_results,
         'resources_results': resources_results,
         'theme_results': theme_results,
-        'layer_results': layer_results
+        'layer_results': layer_results,
+        'sum_data_results': sum_data_results,
     });


### PR DESCRIPTION
`sum_data_results` is used in the mida search result page to display the number of search results in the "data" category in the section header

ex: "158" 
<img width="1058" height="59" alt="Screenshot 2025-10-28 at 11 23 09 AM" src="https://github.com/user-attachments/assets/41a53c7e-7062-4dee-8750-38a54d72859f" />
