### PR TITLE
New main block in base.html for simpler redesign

### DIFF
--- a/marco/marco_site/templates/base.html
+++ b/marco/marco_site/templates/base.html
@@ -63,6 +63,7 @@
 </header>
 {% endblock %} <!-- header_tag -->
 
+{% block main %}
 <div>
     {% block outer_content %}
     {% block page_header_container %}
@@ -96,6 +97,7 @@
 </footer>
 {% endblock footer_wrap %}
 {% endblock outer_content %}
+{% endblock main %}
 
 {% compress js %}
 <script src="{% static 'jquery/dist/jquery.js' %}"></script>


### PR DESCRIPTION
This pull request introduces a new `main` block in the `base.html` template to better structure the page content. This allows child templates to override or extend the main content area more easily.

Template structure improvements:

* Added a `{% block main %}` wrapping the main content section in `base.html` to provide a clearer and more flexible structure for template inheritance. [[1]](diffhunk://#diff-6cb11d6aec8df0bae583a4411e2b6fd081a2f292d9f6c8e7208c3b143e7b3de5R66) [[2]](diffhunk://#diff-6cb11d6aec8df0bae583a4411e2b6fd081a2f292d9f6c8e7208c3b143e7b3de5R100)