### PR TITLE
Elastic snapshot support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ vagrant
 .sass-cache
 node_modules
 
+docker/backups/
 docker/media/
 docker/static/
 docker/entrypoint.sh

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -144,7 +144,7 @@ services:
     image: kibana:8.19.12
     profiles: ["dev"]  # Only start Kibana in dev profile
     ports:
-      - 5601:5601
+      - 127.0.0.1:5601:5601
     environment:
       ELASTICSEARCH_HOSTS: http://elastic:9200
     networks:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -116,6 +116,7 @@ services:
     image: elasticsearch:8.19.12
     volumes:
       - es-volume:/usr/share/elasticsearch/data
+      - ./backups/elasticsearch:/usr/share/elasticsearch/backups
     environment:
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
@@ -123,12 +124,15 @@ services:
       - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
       - bootstrap.memory_lock=true
       - reindex.remote.whitelist=${ES_REINDEX_REMOTE_WHITELIST}
-      - xpack.security.enabled=false
+      - xpack.security.enabled=false # DO NOT EXPOSE ELASTIC TO THE INTERNET!!!
+      - path.repo=/usr/share/elasticsearch/backups
     ports:
       - 9200:9200
       - 9300:9300
     networks:
       - madronanetwork
+    group_add:
+      - "0"  # Add the elasticsearch user to the root group to allow backup permissions
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow"]
       interval: 30s

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -152,7 +152,7 @@ services:
     depends_on:
       elastic:
         condition: service_healthy
-    restart: always
+    restart: no
 
   nginx:
     image: nginx:alpine
@@ -168,7 +168,7 @@ services:
     depends_on:
       - app
       - geoportal
-    restart: unless-stopped
+    restart: no
 
 volumes:
   postgis_data:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -140,6 +140,36 @@ services:
       retries: 10
     restart: always
 
+  kibana:
+    image: kibana:8.19.12
+    profiles: ["dev"]  # Only start Kibana in dev profile
+    ports:
+      - 5601:5601
+    environment:
+      ELASTICSEARCH_HOSTS: http://elastic:9200
+    networks:
+      - madronanetwork
+    depends_on:
+      elastic:
+        condition: service_healthy
+    restart: always
+
+  nginx:
+    image: nginx:alpine
+    profiles: ["dev"]  # Only start nginx in dev profile
+    ports:
+      - "8081:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./static:/vol/web/static:ro
+      - ./media:/usr/local/apps/madrona-portal/media:ro
+    networks:
+      - madronanetwork
+    depends_on:
+      - app
+      - geoportal
+    restart: unless-stopped
+
 volumes:
   postgis_data:
   redis_data:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -124,7 +124,9 @@ services:
       - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
       - bootstrap.memory_lock=true
       - reindex.remote.whitelist=${ES_REINDEX_REMOTE_WHITELIST}
-      - xpack.security.enabled=false # DO NOT EXPOSE ELASTIC TO THE INTERNET!!!
+      # Disable security so that GeoPortal can write to Elasticsearch.
+      # DO NOT EXPOSE ELASTIC TO THE INTERNET until we solve for this and enable xpack.security.
+      - xpack.security.enabled=false 
       - path.repo=/usr/share/elasticsearch/backups
     ports:
       - 9200:9200

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -13,13 +13,13 @@ server {
     # Increase client body size for file uploads
     client_max_body_size 100M;
 
-    # TODO - this was on prod - what is it?
+    # For reference: SCCWRP server also hosted a WAF - we may need to restore this on AWS.
     # location /geospatial/ {
     #     alias /var/www/html/geospatial/;
     #     autoindex on;
     # }
 
-    # TODO: Add munin!
+    # For reference only: add Munin and its static files
     # location /munin/static/ {
     #         alias /etc/munin/static/;
     # }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -15,7 +15,7 @@ server {
 
     # TODO - this was on prod - what is it?
     # location /geospatial/ {
-    #     alias /var/www/html/geopatial/;
+    #     alias /var/www/html/geospatial/;
     #     autoindex on;
     # }
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,141 @@
+server {
+    listen 80;
+    server_name _;
+
+    # Use Docker's internal DNS so upstream hostnames are resolved at
+    # request time, not at nginx startup (avoids "host not found" errors
+    # when a backend container hasn't started yet).
+    resolver 127.0.0.11 valid=30s;
+    # TODO: consider writing logs to specific file
+    # access_log /var/log/nginx/wcoa.access.log;
+    # error_log /var/log/nginx/wcoa.error.log;
+    
+    # Increase client body size for file uploads
+    client_max_body_size 100M;
+
+    # TODO - this was on prod - what is it?
+    # location /geospatial/ {
+    #     alias /var/www/html/geopatial/;
+    #     autoindex on;
+    # }
+
+    # TODO: Add munin!
+    # location /munin/static/ {
+    #         alias /etc/munin/static/;
+    # }
+
+    # location /munin {
+    #         alias /var/cache/munin/www;
+    # }
+
+    location /static {
+        # Static files served from Docker volume
+        alias /vol/web/static/;
+        # prevent caching
+        add_header Last-Modified $date_gmt;
+        add_header Cache-Control 'no-store, no-cache, must-revalidate';
+        add_header Pragma 'no-cache';
+        add_header Expires 0;
+        if_modified_since off;
+        expires off;
+        etag off;
+    }
+
+    location /media {
+        # Media files served from Docker volume
+        alias /usr/local/apps/madrona-portal/media/;
+    }
+
+    location /favicon.ico {
+        # Favicon served from static volume
+        alias /vol/web/favicon.ico;
+    }
+
+    # Elasticsearch routing - route search/doc/metadata requests to Elasticsearch
+    location ~ ^(/_search/|/_doc/|/metadata).*$ {
+        set $elastic_backend http://elastic:9200;
+        proxy_pass $elastic_backend;
+        proxy_redirect off;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 60s;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # ENABLE CORS
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            # Custom headers and headers various browsers *should* be OK with but are not
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            # Tell client that this pre-flight info is valid for 20 days
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+        if ($request_method = 'POST') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        }
+        if ($request_method = 'GET') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        }
+    }
+
+    # Geoportal management interfaces routing
+    location ~ ^/(manager|host-manager|semantix|solr|gc|geoportal|harvester).*$ {
+        set $geoportal_backend http://geoportal:8080;
+        proxy_pass $geoportal_backend;
+        proxy_redirect off;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 60s;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # ENABLE CORS
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            # Custom headers and headers various browsers *should* be OK with but are not
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            # Tell client that this pre-flight info is valid for 20 days
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+        if ($request_method = 'POST') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        }
+        if ($request_method = 'GET') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        }
+    }
+    
+    # Default routing - everything else goes to Django app
+    location / {
+        set $app_backend http://app:8008;
+        proxy_pass $app_backend;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+


### PR DESCRIPTION
This PR Adds two pieces:
* Configures Elasticsearch to use local directory for creating and maintaining snapshots/repositories
* Adds new "dev" profile so developers can 
   * use nginx to test integration between GeoPortal's stack and Madrona-Portal's
   * use Kibana to explore Elasticsearch state with a GUI